### PR TITLE
build with Windows VisualStudio 2010.

### DIFF
--- a/Chacha20/chacha20_simple.c
+++ b/Chacha20/chacha20_simple.c
@@ -19,6 +19,12 @@ This implementation is intended to be simple, many optimizations can be performe
 #include <string.h>
 #include "chacha20_simple.h"
 
+#ifdef _WIN32
+	#define INLINE
+#else
+	#define INLINE inline
+#endif
+
 void chacha20_setup(chacha20_ctx *ctx, const uint8_t *key, size_t length, uint8_t nonce[8])
 {
   const char *constants = (length == 32) ? "expand 32-byte k" : "expand 16-byte k";
@@ -123,7 +129,7 @@ void chacha20_encrypt(chacha20_ctx *ctx, const uint8_t *in, uint8_t *out, size_t
   }
 }
 
-void chacha20_decrypt(chacha20_ctx *ctx, const uint8_t *in, uint8_t *out, size_t length)
+void INLINE chacha20_decrypt(chacha20_ctx *ctx, const uint8_t *in, uint8_t *out, size_t length)
 {
   chacha20_encrypt(ctx, in, out, length);
 }

--- a/Configuration.h
+++ b/Configuration.h
@@ -17,7 +17,11 @@
 #define _manufactuerName "ET Chan"   //Manufactuer
 #define devicePassword "523-12-643" //Password
 #define deviceUUID "62F47751-8F26-46BF-9552-8F4238E67D60"   //UUID, for pair verify
+#ifdef _WIN32
+#define controllerRecordsAddress "PHK_controller" //Where to store the client keys
+#else
 #define controllerRecordsAddress "/var/PHK_controller" //Where to store the client keys
+#endif
 
 //Number of client
 /*
@@ -38,6 +42,12 @@
 
 #include <openssl/sha.h>
 #include <stdint.h>
+
+#ifdef WIN32
+#include <process.h>
+#include <io.h>
+#else
+#endif
 #include <unistd.h>
 
 typedef SHA512_CTX SHACTX;

--- a/PHKAccessory.cpp
+++ b/PHKAccessory.cpp
@@ -328,6 +328,8 @@ void *announce(void *info) {
     
     delete [] desc;
     delete [] info;
+
+	return NULL;
 }
 
 void updateValueFromDeviceEnd(characteristics *c, int aid, int iid, string value) {
@@ -378,7 +380,7 @@ void handleAccessory(const char *request, unsigned int requestLen, char **reply,
     
     char *replyData = NULL;  unsigned short replyDataLen = 0;
     
-    int statusCode;
+    int statusCode = 0;
     
     const char *protocol = "HTTP/1.1";
     const char *returnType = hapJsonType;

--- a/PHKAccessory.h
+++ b/PHKAccessory.h
@@ -93,7 +93,7 @@ typedef enum {
     charType_videoRotation      = 0x3C,
     charType_videoValAttr       = 0x3D,
     
-#pragma - The following is only default by the device after iOS 9
+//#pragma - The following is only default by the device after iOS 9
     
     charType_firmwareRevision   = 0x52,
     charType_hardwareRevision   = 0x53,
@@ -140,7 +140,7 @@ typedef enum {
     charType_sensorChargingState= 0x8F,
     
     
-#pragma - The following is service provide
+//#pragma - The following is service provide
     serviceType_accessoryInfo      = 0x3E,
     serviceType_camera             = 0x3F,
     serviceType_fan                = 0x40,
@@ -177,13 +177,13 @@ typedef enum {
     serviceType_battery            = 0x96,
     serviceType_carbonDioxideSensor= 0x97,
     
-#pragma - The following is for bluetooth characteristic
+//#pragma - The following is for bluetooth characteristic
     btCharType_pairSetup = 0x4C,
     btCharType_pairVerify = 0x4E,
     btCharType_pairingFeature = 0x4F,
     btCharType_pairings = 0x50,
     btCharType_serviceInstanceID = 0x51,
-#pragma - The following is for bluetooth service
+//#pragma - The following is for bluetooth service
     btServiceType_accessoryInformation = 0xFED3,
     btServiceType_camera            = 0xFEC9,
     btServiceType_fan               = 0xFECB,
@@ -230,8 +230,12 @@ public:
 class boolCharacteristics: public characteristics {
 public:
     bool _value;
-    void (*valueChangeFunctionCall)(bool oldValue, bool newValue) = NULL;
-    boolCharacteristics(unsigned short _type, int _premission): characteristics(_type, _premission) {}
+    void (*valueChangeFunctionCall)(bool oldValue, bool newValue);
+    boolCharacteristics(unsigned short _type, int _premission)
+		: valueChangeFunctionCall(NULL)
+		, characteristics(_type, _premission) 
+	{
+	}
     virtual string value() {
         if (_value)
             return "1";
@@ -251,15 +255,23 @@ public:
     float _value;
     const float _minVal, _maxVal, _step;
     const unit _unit;
-    void (*valueChangeFunctionCall)(float oldValue, float newValue) = NULL;
-    floatCharacteristics(unsigned short _type, int _premission, float minVal, float maxVal, float step, unit charUnit): characteristics(_type, _premission), _minVal(minVal), _maxVal(maxVal), _step(step), _unit(charUnit) {}
+    void (*valueChangeFunctionCall)(float oldValue, float newValue);
+    floatCharacteristics(unsigned short _type, int _premission, float minVal, float maxVal, float step, unit charUnit)
+		: valueChangeFunctionCall(NULL)
+		,characteristics(_type, _premission)
+		, _minVal(minVal)
+		, _maxVal(maxVal)
+		, _step(step)
+		, _unit(charUnit) 
+	{
+	}
     virtual string value() {
         char temp[16];
         snprintf(temp, 16, "%f", _value);
         return temp;
     }
     virtual void setValue(string str) {
-        float temp = atof(str.c_str());
+        float temp = (float) atof(str.c_str());
         if (temp == temp) {
             if (valueChangeFunctionCall)
                 valueChangeFunctionCall(_value, temp);
@@ -274,9 +286,16 @@ public:
     int _value;
     const int _minVal, _maxVal, _step;
     const unit _unit;
-    void (*valueChangeFunctionCall)(int oldValue, int newValue) = NULL;
-    intCharacteristics(unsigned short _type, int _premission, int minVal, int maxVal, int step, unit charUnit): characteristics(_type, _premission), _minVal(minVal), _maxVal(maxVal), _step(step), _unit(charUnit) {
-        _value = minVal;
+    void (*valueChangeFunctionCall)(int oldValue, int newValue);
+    intCharacteristics(unsigned short _type, int _premission, int minVal, int maxVal, int step, unit charUnit)
+		: valueChangeFunctionCall(NULL)
+		, characteristics(_type, _premission)
+		, _minVal(minVal)
+		, _maxVal(maxVal)
+		, _step(step)
+		, _unit(charUnit) 
+	{
+		_value = minVal;
     }
     virtual string value() {
         char temp[16];
@@ -284,11 +303,11 @@ public:
         return temp;
     }
     virtual void setValue(string str) {
-        float temp = atoi(str.c_str());
+        float temp = (float)atoi(str.c_str());
         if (temp == temp) {
             if (valueChangeFunctionCall)
-                valueChangeFunctionCall(_value, temp);
-            _value = temp;
+                valueChangeFunctionCall(_value, (int)temp);
+            _value = (int) temp;
         }
     }
     virtual string describe();
@@ -298,8 +317,13 @@ class stringCharacteristics: public characteristics {
 public:
     string _value;
     const unsigned short maxLen;
-    void (*valueChangeFunctionCall)(string oldValue, string newValue) = NULL;
-    stringCharacteristics(unsigned short _type, int _premission, unsigned short _maxLen): characteristics(_type, _premission), maxLen(_maxLen) {}
+    void (*valueChangeFunctionCall)(string oldValue, string newValue);
+    stringCharacteristics(unsigned short _type, int _premission, unsigned short _maxLen)
+		: valueChangeFunctionCall(NULL)
+		, characteristics(_type, _premission)
+		, maxLen(_maxLen)
+	{
+	}
     virtual string value() {
         return "\""+_value+"\"";
     }
@@ -324,7 +348,7 @@ public:
 
 class Accessory {
 public:
-    int numberOfInstance = 0;
+    int numberOfInstance;
     int aid;
     vector<Service *>_services;
     void addService(Service *ser) {
@@ -357,7 +381,9 @@ public:
         }
         return exist;
     }
-    Accessory() {}
+    Accessory() : numberOfInstance (0)
+	{
+	}
     short numberOfService() { return _services.size(); }
     Service *serviceAtIndex(int index) {
         for (vector<Service *>::iterator it = _services.begin(); it != _services.end(); it++) {
@@ -383,8 +409,9 @@ public:
 class AccessorySet {
 private:
     vector<Accessory *> _accessories;
-    int _aid = 0;
+    int _aid;
     AccessorySet() {
+		_aid = 0;
         pthread_mutex_init(&accessoryMutex, NULL);
     }
     AccessorySet(AccessorySet const&);

--- a/PHKNetworkIP.h
+++ b/PHKNetworkIP.h
@@ -7,10 +7,19 @@
 //
 //
 
-#include <stdio.h>
-#include <sys/socket.h>
-#include <netinet/in.h>
-#include <dns_sd.h>
+#ifdef _WIN32
+	#include <Ws2tcpip.h>
+	#include <stdio.h>
+	#include <stdlib.h>
+	#include <time.h>
+	#include <pthread.h>
+#else
+	#include <stdio.h>
+	#include <sys/socket.h>
+	#include <netinet/in.h>
+#endif
+
+#include <dns_sd.h>  // linux->avahi  windows->bonjoursdk
 #include <cstring>
 #include <string>
 
@@ -79,19 +88,29 @@ public:
 
 class PHKNetworkMessageDataRecord {
 public:
-    unsigned char index = 0;
-    char *data = 0;
-    unsigned int length = 0;
-    bool activate = false;
+    unsigned char index;
+    char *data;
+    unsigned int length;
+    bool activate;
+	PHKNetworkMessageDataRecord()
+		: index(0)
+		, data(0)
+		, length(0)
+		, activate(false)
+	{
+	}
     ~PHKNetworkMessageDataRecord();
     PHKNetworkMessageDataRecord &operator=(const PHKNetworkMessageDataRecord&);
 };
 
 class PHKNetworkMessageData {
     PHKNetworkMessageDataRecord records[10];
-    unsigned char count = 0;
+    unsigned char count;
 public:
-    PHKNetworkMessageData() {}
+    PHKNetworkMessageData()
+	{
+		this->count = 0;
+	}
     PHKNetworkMessageData(const char *rawData, unsigned short len);
     PHKNetworkMessageData(const PHKNetworkMessageData &data);
     PHKNetworkMessageData &operator=(const PHKNetworkMessageData &);
@@ -127,13 +146,13 @@ public:
     pthread_t thread;
     pthread_mutex_t mutex;
 
-    bool connected = false;
+    bool connected;
 
     uint8_t controllerToAccessoryKey[32];
     uint8_t accessoryToControllerKey[32];
-    unsigned long long numberOfMsgRec = 0;
-    unsigned long long numberOfMsgSend = 0;
-    int subSocket = -1;
+    unsigned long long numberOfMsgRec;
+    unsigned long long numberOfMsgSend;
+    int subSocket;
     char buffer[4096];
 
     void *notificationList[numberOfNotifiableValue];
@@ -141,6 +160,14 @@ public:
     void handlePairSeup();
     void handlePairVerify();
     void handleAccessoryRequest();
+
+	connectionInfo()
+		: subSocket(0)
+		, numberOfMsgRec(0)
+		, numberOfMsgSend(0)
+		, connected(false)
+	{
+	}
 
     void Poly1305_GenKey(const unsigned char * key, uint8_t * buf, uint16_t len, Poly1305Type_t type, char* verify);
 

--- a/Personal-HomeKit-HAP.vcxproj
+++ b/Personal-HomeKit-HAP.vcxproj
@@ -1,0 +1,140 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|Win32">
+      <Configuration>Debug</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|Win32">
+      <Configuration>Release</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>{89C81753-1AFE-4F3C-B0FB-159F9BC02693}</ProjectGuid>
+    <RootNamespace>PersonalHomeKitHAP</RootNamespace>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <CharacterSet>MultiByte</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>MultiByte</CharacterSet>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <IncludePath>$(VCInstallDir)include;$(VCInstallDir)atlmfc\include;$(WindowsSdkDir)include;$(FrameworkSDKDir)\include</IncludePath>
+    <LibraryPath>$(SolutionDir)$(Configuration)\;$(LibraryPath)</LibraryPath>
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>Disabled</Optimization>
+      <PreprocessorDefinitions>HomeKitLog=1;OPENSSL_ENGINE;_CRT_SECURE_NO_DEPRECATE;STDC_HEADERS;WIN32;_MBCS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>..\openssl\include;windows_support_include;$(BONJOUR_SDK_HOME)/Include</AdditionalIncludeDirectories>
+      <DisableSpecificWarnings>4996</DisableSpecificWarnings>
+    </ClCompile>
+    <Link>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <AdditionalDependencies>openssl.lib;$(BONJOUR_SDK_HOME)/Lib/$(PlatformName)/dnssd.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>MaxSpeed</Optimization>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+    </ClCompile>
+    <Link>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemGroup>
+    <ClInclude Include="Accessory.h" />
+    <ClInclude Include="Chacha20\chacha20_simple.h" />
+    <ClInclude Include="curve25519\curve25519-donna.h" />
+    <ClInclude Include="ed25519-donna\curve25519-donna-32bit.h" />
+    <ClInclude Include="ed25519-donna\curve25519-donna-helpers.h" />
+    <ClInclude Include="ed25519-donna\ed25519-donna-32bit-tables.h" />
+    <ClInclude Include="ed25519-donna\ed25519-donna-basepoint-table.h" />
+    <ClInclude Include="ed25519-donna\ed25519-donna-batchverify.h" />
+    <ClInclude Include="ed25519-donna\ed25519-donna-impl-base.h" />
+    <ClInclude Include="ed25519-donna\ed25519-donna-portable-identify.h" />
+    <ClInclude Include="ed25519-donna\ed25519-donna-portable.h" />
+    <ClInclude Include="ed25519-donna\ed25519-donna.h" />
+    <ClInclude Include="ed25519-donna\ed25519-hash.h" />
+    <ClInclude Include="ed25519-donna\ed25519-randombytes.h" />
+    <ClInclude Include="ed25519-donna\ed25519.h" />
+    <ClInclude Include="ed25519-donna\modm-donna-32bit.h" />
+    <ClInclude Include="PHKAccessory.h" />
+    <ClInclude Include="PHKControllerRecord.h" />
+    <ClInclude Include="PHKNetworkIP.h" />
+    <ClInclude Include="poly1305-opt-master\poly1305.h" />
+    <ClInclude Include="rfc6234-master\hkdf.h" />
+    <ClInclude Include="rfc6234-master\sha.h" />
+    <ClInclude Include="srp\acconfig.h" />
+    <ClInclude Include="srp\config.h" />
+    <ClInclude Include="srp\cstr.h" />
+    <ClInclude Include="srp\endXXent.h" />
+    <ClInclude Include="srp\getXXbyYY.h" />
+    <ClInclude Include="srp\getXXent.h" />
+    <ClInclude Include="srp\nsswitch.h" />
+    <ClInclude Include="srp\nss_defs.h" />
+    <ClInclude Include="srp\NTconfig.h" />
+    <ClInclude Include="srp\nys_config.h" />
+    <ClInclude Include="srp\setXXent.h" />
+    <ClInclude Include="srp\srp.h" />
+    <ClInclude Include="srp\srp_aux.h" />
+    <ClInclude Include="srp\t_client.h" />
+    <ClInclude Include="srp\t_defines.h" />
+    <ClInclude Include="srp\t_pwd.h" />
+    <ClInclude Include="srp\t_read.h" />
+    <ClInclude Include="srp\t_server.h" />
+    <ClInclude Include="srp\t_sha.h" />
+    <ClInclude Include="srp\yp_misc.h" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="Accessory.cpp" />
+    <ClCompile Include="Chacha20\chacha20_simple.c" />
+    <ClCompile Include="curve25519\curve25519-donna.c" />
+    <ClCompile Include="ed25519-donna\ed25519.c" />
+    <ClCompile Include="main.cpp" />
+    <ClCompile Include="PHKAccessory.cpp" />
+    <ClCompile Include="PHKControllerRecord.cpp" />
+    <ClCompile Include="PHKNetworkIP.cpp" />
+    <ClCompile Include="poly1305-opt-master\poly1305.c" />
+    <ClCompile Include="rfc6234-master\hkdf.c" />
+    <ClCompile Include="rfc6234-master\hmac.c" />
+    <ClCompile Include="rfc6234-master\sha.c" />
+    <ClCompile Include="srp\cstr.c" />
+    <ClCompile Include="srp\srp.c" />
+    <ClCompile Include="srp\srp6_server.c" />
+    <ClCompile Include="srp\t_conf.c" />
+    <ClCompile Include="srp\t_conv.c" />
+    <ClCompile Include="srp\t_math.c" />
+    <ClCompile Include="srp\t_misc.c" />
+    <ClCompile Include="srp\t_pw.c" />
+    <ClCompile Include="srp\t_read.c" />
+    <ClCompile Include="srp\t_truerand.c" />
+  </ItemGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+  </ImportGroup>
+</Project>

--- a/Personal-HomeKit-HAP.vcxproj.filters
+++ b/Personal-HomeKit-HAP.vcxproj.filters
@@ -1,0 +1,201 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <Filter Include="Chacha20">
+      <UniqueIdentifier>{f6cf986d-69f1-47dc-b0c8-1e6ddbd14868}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="curve25519">
+      <UniqueIdentifier>{bd079260-fcdd-4ac0-a261-86033f0cedb8}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="ed25519-donna">
+      <UniqueIdentifier>{7bddeea4-8d42-4bda-9889-d3a654eac7ce}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="poly1305-opt-master">
+      <UniqueIdentifier>{bae2b6a2-57ef-4b8d-b5a6-197d87ab0f76}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="rfc6234-master">
+      <UniqueIdentifier>{a842e132-cea7-4d9a-a055-6ff3ebacd4f7}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="srp">
+      <UniqueIdentifier>{5146eaa5-edee-463b-98b7-3b5e2a5ef71f}</UniqueIdentifier>
+    </Filter>
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="Chacha20\chacha20_simple.h">
+      <Filter>Chacha20</Filter>
+    </ClInclude>
+    <ClInclude Include="curve25519\curve25519-donna.h">
+      <Filter>curve25519</Filter>
+    </ClInclude>
+    <ClInclude Include="ed25519-donna\ed25519-donna-basepoint-table.h">
+      <Filter>ed25519-donna</Filter>
+    </ClInclude>
+    <ClInclude Include="ed25519-donna\ed25519-donna-batchverify.h">
+      <Filter>ed25519-donna</Filter>
+    </ClInclude>
+    <ClInclude Include="ed25519-donna\ed25519-donna-impl-base.h">
+      <Filter>ed25519-donna</Filter>
+    </ClInclude>
+    <ClInclude Include="ed25519-donna\ed25519-donna-portable.h">
+      <Filter>ed25519-donna</Filter>
+    </ClInclude>
+    <ClInclude Include="ed25519-donna\ed25519-donna-portable-identify.h">
+      <Filter>ed25519-donna</Filter>
+    </ClInclude>
+    <ClInclude Include="ed25519-donna\ed25519-hash.h">
+      <Filter>ed25519-donna</Filter>
+    </ClInclude>
+    <ClInclude Include="ed25519-donna\ed25519-randombytes.h">
+      <Filter>ed25519-donna</Filter>
+    </ClInclude>
+    <ClInclude Include="ed25519-donna\modm-donna-32bit.h">
+      <Filter>ed25519-donna</Filter>
+    </ClInclude>
+    <ClInclude Include="ed25519-donna\curve25519-donna-32bit.h">
+      <Filter>ed25519-donna</Filter>
+    </ClInclude>
+    <ClInclude Include="ed25519-donna\curve25519-donna-helpers.h">
+      <Filter>ed25519-donna</Filter>
+    </ClInclude>
+    <ClInclude Include="ed25519-donna\ed25519.h">
+      <Filter>ed25519-donna</Filter>
+    </ClInclude>
+    <ClInclude Include="ed25519-donna\ed25519-donna.h">
+      <Filter>ed25519-donna</Filter>
+    </ClInclude>
+    <ClInclude Include="ed25519-donna\ed25519-donna-32bit-tables.h">
+      <Filter>ed25519-donna</Filter>
+    </ClInclude>
+    <ClInclude Include="poly1305-opt-master\poly1305.h">
+      <Filter>poly1305-opt-master</Filter>
+    </ClInclude>
+    <ClInclude Include="rfc6234-master\sha.h">
+      <Filter>rfc6234-master</Filter>
+    </ClInclude>
+    <ClInclude Include="rfc6234-master\hkdf.h">
+      <Filter>rfc6234-master</Filter>
+    </ClInclude>
+    <ClInclude Include="srp\getXXent.h">
+      <Filter>srp</Filter>
+    </ClInclude>
+    <ClInclude Include="srp\nss_defs.h">
+      <Filter>srp</Filter>
+    </ClInclude>
+    <ClInclude Include="srp\nsswitch.h">
+      <Filter>srp</Filter>
+    </ClInclude>
+    <ClInclude Include="srp\NTconfig.h">
+      <Filter>srp</Filter>
+    </ClInclude>
+    <ClInclude Include="srp\nys_config.h">
+      <Filter>srp</Filter>
+    </ClInclude>
+    <ClInclude Include="srp\setXXent.h">
+      <Filter>srp</Filter>
+    </ClInclude>
+    <ClInclude Include="srp\srp.h">
+      <Filter>srp</Filter>
+    </ClInclude>
+    <ClInclude Include="srp\srp_aux.h">
+      <Filter>srp</Filter>
+    </ClInclude>
+    <ClInclude Include="srp\t_client.h">
+      <Filter>srp</Filter>
+    </ClInclude>
+    <ClInclude Include="srp\t_defines.h">
+      <Filter>srp</Filter>
+    </ClInclude>
+    <ClInclude Include="srp\t_pwd.h">
+      <Filter>srp</Filter>
+    </ClInclude>
+    <ClInclude Include="srp\t_read.h">
+      <Filter>srp</Filter>
+    </ClInclude>
+    <ClInclude Include="srp\t_server.h">
+      <Filter>srp</Filter>
+    </ClInclude>
+    <ClInclude Include="srp\t_sha.h">
+      <Filter>srp</Filter>
+    </ClInclude>
+    <ClInclude Include="srp\yp_misc.h">
+      <Filter>srp</Filter>
+    </ClInclude>
+    <ClInclude Include="srp\acconfig.h">
+      <Filter>srp</Filter>
+    </ClInclude>
+    <ClInclude Include="srp\config.h">
+      <Filter>srp</Filter>
+    </ClInclude>
+    <ClInclude Include="srp\cstr.h">
+      <Filter>srp</Filter>
+    </ClInclude>
+    <ClInclude Include="srp\endXXent.h">
+      <Filter>srp</Filter>
+    </ClInclude>
+    <ClInclude Include="srp\getXXbyYY.h">
+      <Filter>srp</Filter>
+    </ClInclude>
+    <ClInclude Include="PHKAccessory.h" />
+    <ClInclude Include="PHKNetworkIP.h" />
+    <ClInclude Include="PHKControllerRecord.h" />
+    <ClInclude Include="Accessory.h" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="Chacha20\chacha20_simple.c">
+      <Filter>Chacha20</Filter>
+    </ClCompile>
+    <ClCompile Include="curve25519\curve25519-donna.c">
+      <Filter>curve25519</Filter>
+    </ClCompile>
+    <ClCompile Include="ed25519-donna\ed25519.c">
+      <Filter>ed25519-donna</Filter>
+    </ClCompile>
+    <ClCompile Include="poly1305-opt-master\poly1305.c">
+      <Filter>poly1305-opt-master</Filter>
+    </ClCompile>
+    <ClCompile Include="rfc6234-master\sha.c">
+      <Filter>rfc6234-master</Filter>
+    </ClCompile>
+    <ClCompile Include="rfc6234-master\hkdf.c">
+      <Filter>rfc6234-master</Filter>
+    </ClCompile>
+    <ClCompile Include="rfc6234-master\hmac.c">
+      <Filter>rfc6234-master</Filter>
+    </ClCompile>
+    <ClCompile Include="srp\srp.c">
+      <Filter>srp</Filter>
+    </ClCompile>
+    <ClCompile Include="srp\srp6_server.c">
+      <Filter>srp</Filter>
+    </ClCompile>
+    <ClCompile Include="srp\t_conf.c">
+      <Filter>srp</Filter>
+    </ClCompile>
+    <ClCompile Include="srp\t_conv.c">
+      <Filter>srp</Filter>
+    </ClCompile>
+    <ClCompile Include="srp\t_math.c">
+      <Filter>srp</Filter>
+    </ClCompile>
+    <ClCompile Include="srp\t_misc.c">
+      <Filter>srp</Filter>
+    </ClCompile>
+    <ClCompile Include="srp\t_pw.c">
+      <Filter>srp</Filter>
+    </ClCompile>
+    <ClCompile Include="srp\t_read.c">
+      <Filter>srp</Filter>
+    </ClCompile>
+    <ClCompile Include="srp\t_truerand.c">
+      <Filter>srp</Filter>
+    </ClCompile>
+    <ClCompile Include="srp\cstr.c">
+      <Filter>srp</Filter>
+    </ClCompile>
+    <ClCompile Include="PHKAccessory.cpp" />
+    <ClCompile Include="PHKNetworkIP.cpp" />
+    <ClCompile Include="PHKControllerRecord.cpp" />
+    <ClCompile Include="Accessory.cpp" />
+    <ClCompile Include="main.cpp" />
+  </ItemGroup>
+</Project>

--- a/Personal-HomeKit-HAP.vcxproj.user
+++ b/Personal-HomeKit-HAP.vcxproj.user
@@ -1,0 +1,3 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+</Project>

--- a/ed25519-donna/ed25519.c
+++ b/ed25519-donna/ed25519.c
@@ -16,7 +16,6 @@
 
 #include "ed25519-donna.h"
 #include "ed25519.h"
-#include "ed25519-randombytes.h"
 #include "ed25519-hash.h"
 
 /*
@@ -148,3 +147,5 @@ ED25519_FN(curved25519_scalarmult_basepoint) (curved25519_key pk, const curved25
 	curve25519_contract(pk, yplusz);
 }
 
+//This does not work unless it is at the bottom because of the order of winsock used in windows openssl.
+#include "ed25519-randombytes.h"

--- a/main.cpp
+++ b/main.cpp
@@ -60,7 +60,11 @@ int main(int argc, const char * argv[]) {
 #if PowerOnTest==1
     printf("poweron: %d\n", poly1305_power_on_self_test());
 #endif
-    
+
+#ifdef _WIN32
+	WSADATA wsaData;
+	WSAStartup(2, &wsaData);
+#endif    
     // insert code here...
     if (argc > 1) {
 	//If there's some argument
@@ -69,11 +73,18 @@ int main(int argc, const char * argv[]) {
     }
 
     initAccessorySet();
-    setupPort();
+#ifdef _WIN32
+#else
+	setupPort();
+#endif
 
-    PHKNetworkIP networkIP;
+	PHKNetworkIP networkIP;
     do {
         networkIP.handleConnection();
     } while (true);
-    return 0;
+
+#ifdef _WIN32
+	WSACleanup();
+#endif    
+	return 0;
 }

--- a/srp/srp.h
+++ b/srp/srp.h
@@ -51,8 +51,8 @@ typedef int SRP_RESULT;
 
 /* Set the minimum number of bits acceptable in an SRP modulus */
 #define SRP_DEFAULT_MIN_BITS 512
-_TYPE( SRP_RESULT ) SRP_set_modulus_min_bits P((int minbits));
-_TYPE( int ) SRP_get_modulus_min_bits P((void));
+_TYPE( SRP_RESULT ) SRP_set_modulus_min_bits (int minbits);
+_TYPE( int ) SRP_get_modulus_min_bits (void);
 
 /*
  * Sets the "secret size callback" function.
@@ -61,8 +61,8 @@ _TYPE( int ) SRP_get_modulus_min_bits P((void));
  * The default function always returns 256 bits.
  */
 typedef int (_CDECL * SRP_SECRET_BITS_CB)(int modsize);
-_TYPE( SRP_RESULT ) SRP_set_secret_bits_cb P((SRP_SECRET_BITS_CB cb));
-_TYPE( int ) SRP_get_secret_bits P((int modsize));
+_TYPE( SRP_RESULT ) SRP_set_secret_bits_cb (SRP_SECRET_BITS_CB cb);
+_TYPE( int ) SRP_get_secret_bits (int modsize);
 
 typedef struct srp_st SRP;
 
@@ -97,15 +97,15 @@ struct srp_server_lu_st {
  * called to do lookups.
  */
 _TYPE( SRP_SERVER_LOOKUP * )
-     SRP_SERVER_LOOKUP_new P((SRP_SERVER_LOOKUP_METHOD * meth));
-_TYPE( SRP_RESULT ) SRP_SERVER_LOOKUP_free P((SRP_SERVER_LOOKUP * slu));
-_TYPE( SRP_RESULT ) SRP_SERVER_do_lookup P((SRP_SERVER_LOOKUP * slu,
-					    SRP * srp, cstr * username));
+     SRP_SERVER_LOOKUP_new (SRP_SERVER_LOOKUP_METHOD * meth);
+_TYPE( SRP_RESULT ) SRP_SERVER_LOOKUP_free (SRP_SERVER_LOOKUP * slu);
+_TYPE( SRP_RESULT ) SRP_SERVER_do_lookup (SRP_SERVER_LOOKUP * slu,
+					    SRP * srp, cstr * username);
 
 /*
  * SRP_SERVER_system_lookup supercedes SRP_server_init_user.
  */
-_TYPE( SRP_SERVER_LOOKUP * ) SRP_SERVER_system_lookup P((void));
+_TYPE( SRP_SERVER_LOOKUP * ) SRP_SERVER_system_lookup (void);
 
 /*
  * Client Parameter Verification API
@@ -213,8 +213,8 @@ _TYPE( SRP_RESULT ) SRP_finalize_library();
  * the object operates in.  SRP_free() frees it.
  * (See RFC2945 method definitions below.)
  */
-_TYPE( SRP * )      SRP_new P((SRP_METHOD * meth));
-_TYPE( SRP_RESULT ) SRP_free P((SRP * srp));
+_TYPE( SRP * )      SRP_new (SRP_METHOD * meth);
+_TYPE( SRP_RESULT ) SRP_free (SRP * srp);
 
 /*
  * Use the supplied lookup object to look up user parameters and
@@ -224,16 +224,16 @@ _TYPE( SRP_RESULT ) SRP_free P((SRP * srp));
  * SRP_set_authenticator, since the lookup function handles that
  * internally.
  */
-_TYPE( SRP_RESULT ) SRP_set_server_lookup P((SRP * srp,
-					     SRP_SERVER_LOOKUP * lookup));
+_TYPE( SRP_RESULT ) SRP_set_server_lookup (SRP * srp,
+					     SRP_SERVER_LOOKUP * lookup);
 
 /*
  * Use the supplied callback function to verify parameters
  * (modulus, generator) given to the client.
  */
 _TYPE( SRP_RESULT )
-     SRP_set_client_param_verify_cb P((SRP * srp,
-				       SRP_CLIENT_PARAM_VERIFY_CB cb));
+     SRP_set_client_param_verify_cb (SRP * srp,
+				       SRP_CLIENT_PARAM_VERIFY_CB cb);
 
 /*
  * Both client and server must call both SRP_set_username and
@@ -241,14 +241,14 @@ _TYPE( SRP_RESULT )
  * SRP_set_user_raw is an alternative to SRP_set_username that
  * accepts an arbitrary length-bounded octet string as input.
  */
-_TYPE( SRP_RESULT ) SRP_set_username P((SRP * srp, const char * username));
-_TYPE( SRP_RESULT ) SRP_set_user_raw P((SRP * srp, const unsigned char * user,
-					int userlen));
+_TYPE( SRP_RESULT ) SRP_set_username (SRP * srp, const char * username);
+_TYPE( SRP_RESULT ) SRP_set_user_raw (SRP * srp, const unsigned char * user,
+					int userlen);
 _TYPE( SRP_RESULT )
-     SRP_set_params P((SRP * srp,
+     SRP_set_params (SRP * srp,
 		       const unsigned char * modulus, int modlen,
 		       const unsigned char * generator, int genlen,
-		       const unsigned char * salt, int saltlen));
+		       const unsigned char * salt, int saltlen);
 
 /*
  * On the client, SRP_set_authenticator, SRP_gen_exp, and
@@ -270,13 +270,13 @@ _TYPE( SRP_RESULT )
  * SRP_set_authenticator (since it doesn't know the plaintext password).
  */
 _TYPE( SRP_RESULT )
-     SRP_set_authenticator P((SRP * srp, const unsigned char * a, int alen));
+     SRP_set_authenticator (SRP * srp, const unsigned char * a, int alen);
 _TYPE( SRP_RESULT )
-     SRP_set_auth_password P((SRP * srp, const char * password));
+     SRP_set_auth_password (SRP * srp, const char * password);
 _TYPE( SRP_RESULT )
-     SRP_set_auth_password_raw P((SRP * srp,
+     SRP_set_auth_password_raw (SRP * srp,
 				  const unsigned char * password,
-				  int passlen));
+				  int passlen);
 
 /*
  * SRP_gen_pub generates the random exponential residue to send
@@ -293,21 +293,21 @@ _TYPE( SRP_RESULT )
  * although the big integer value will still be available
  * through srp->pubkey in the SRP struct.
  */
-_TYPE( SRP_RESULT ) SRP_gen_pub P((SRP * srp, cstr ** result));
+_TYPE( SRP_RESULT ) SRP_gen_pub (SRP * srp, cstr ** result);
 /*
  * Append the data to the extra data segment.  Authentication will
  * not succeed unless both sides add precisely the same data in
  * the same order.
  */
-_TYPE( SRP_RESULT ) SRP_add_ex_data P((SRP * srp, const unsigned char * data,
-				       int datalen));
+_TYPE( SRP_RESULT ) SRP_add_ex_data (SRP * srp, const unsigned char * data,
+				       int datalen);
 
 /*
  * SRP_compute_key must be called after the previous three methods.
  */
-_TYPE( SRP_RESULT ) SRP_compute_key P((SRP * srp, cstr ** result,
+_TYPE( SRP_RESULT ) SRP_compute_key (SRP * srp, cstr ** result,
 				       const unsigned char * pubkey,
-				       int pubkeylen));
+				       int pubkeylen);
 
 /*
  * On the client, call SRP_respond first to get the response to send
@@ -317,9 +317,9 @@ _TYPE( SRP_RESULT ) SRP_compute_key P((SRP * srp, cstr ** result,
  *
  * It is an error to call SRP_respond with a NULL pointer.
  */
-_TYPE( SRP_RESULT ) SRP_verify P((SRP * srp,
-				  const unsigned char * proof, int prooflen));
-_TYPE( SRP_RESULT ) SRP_respond P((SRP * srp, cstr ** response));
+_TYPE( SRP_RESULT ) SRP_verify (SRP * srp,
+				  const unsigned char * proof, int prooflen);
+_TYPE( SRP_RESULT ) SRP_respond (SRP * srp, cstr ** response);
 
 /* RFC2945-style SRP authentication */
 
@@ -330,17 +330,17 @@ _TYPE( SRP_RESULT ) SRP_respond P((SRP * srp, cstr ** response));
  * RFC2945-style SRP authentication methods.  Use these like:
  * SRP * srp = SRP_new(SRP_RFC2945_client_method());
  */
-_TYPE( SRP_METHOD * ) SRP_RFC2945_client_method P((void));
-_TYPE( SRP_METHOD * ) SRP_RFC2945_server_method P((void));
+_TYPE( SRP_METHOD * ) SRP_RFC2945_client_method (void);
+_TYPE( SRP_METHOD * ) SRP_RFC2945_server_method (void);
 
 /*
  * SRP-6 and SRP-6a authentication methods.
  * SRP-6a is recommended for better resistance to 2-for-1 attacks.
  */
-_TYPE( SRP_METHOD * ) SRP6_client_method P((void));
-_TYPE( SRP_METHOD * ) SRP6_server_method P((void));
-_TYPE( SRP_METHOD * ) SRP6a_client_method P((void));
-_TYPE( SRP_METHOD * ) SRP6a_server_method P((void));
+_TYPE( SRP_METHOD * ) SRP6_client_method (void);
+_TYPE( SRP_METHOD * ) SRP6_server_method (void);
+_TYPE( SRP_METHOD * ) SRP6a_client_method (void);
+_TYPE( SRP_METHOD * ) SRP6a_server_method (void);
 
 /*
  * Convenience function - SRP_server_init_user
@@ -351,12 +351,12 @@ _TYPE( SRP_METHOD * ) SRP6a_server_method P((void));
  * This is deprecated in favor of SRP_SERVER_system_lookup() and
  * the Server Lookup API.
  */
-_TYPE( SRP_RESULT ) SRP_server_init_user P((SRP * srp, const char * username));
+_TYPE( SRP_RESULT ) SRP_server_init_user (SRP * srp, const char * username);
 
 /*
  * Use the named engine for acceleration.
  */
-_TYPE( SRP_RESULT ) SRP_use_engine P((const char * engine));
+_TYPE( SRP_RESULT ) SRP_use_engine (const char * engine);
 
 #ifdef __cplusplus
 }

--- a/srp/srp6_server.c
+++ b/srp/srp6_server.c
@@ -258,6 +258,7 @@ srp6_server_key(SRP * srp, cstr ** result,
   cstr * s;
   BigInteger t1, t2, t3;
   SHACTX ctxt;
+  SHACTX sctx;
   unsigned char dig[SHA_DIGESTSIZE];
   int modlen;
 
@@ -331,7 +332,6 @@ srp6_server_key(SRP * srp, cstr ** result,
   BigIntegerClearFree(t3);
 
   /* convert srp->key into session key, update hashes */
-    SHACTX sctx;
     BigIntegerToCstr(srp->key, s);
     SHAInit(&sctx);
     SHAUpdate(&sctx, s->data, s->length);

--- a/srp/t_defines.h
+++ b/srp/t_defines.h
@@ -90,6 +90,13 @@ char *strchr(), *strrchr(), *strtok();
 
 #include <sys/types.h>
 
+#ifdef WIN32
+#include <process.h>
+#include <io.h>
+#define USE_FTIME 1
+#define USE_RENAME 1
+#define NO_FCHMOD 1
+#else
 #if TIME_WITH_SYS_TIME
 #include <sys/time.h>
 #include <time.h>
@@ -121,12 +128,10 @@ char *strchr(), *strrchr(), *strtok();
 #define TERMIO struct sgttyb
 #define USE_SGTTY
 #endif
+#endif /* WIN32 */
 
-#ifdef WIN32
-#define USE_FTIME 1
-#define USE_RENAME 1
-#define NO_FCHMOD 1
-#endif
+
+
 
 #ifdef USE_FTIME
 #include <sys/timeb.h>

--- a/srp/t_misc.c
+++ b/srp/t_misc.c
@@ -37,11 +37,12 @@
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <fcntl.h>
-#include <sys/time.h>
 
 #ifdef WIN32
 #include <process.h>
 #include <io.h>
+#else
+#include <sys/time.h>
 #endif
 
 #include "t_sha.h"
@@ -78,7 +79,10 @@ SHACTX randctxt;
  * tricks with variable ordering and sometimes define quirky
  * environment variables like $WINDOWID or $_.
  */
+#ifdef _WIN32
+#else
 extern char ** environ;
+#endif
 
 static void
 t_envhash(out)

--- a/windows_support_include/pthread.h
+++ b/windows_support_include/pthread.h
@@ -1,0 +1,56 @@
+#pragma once
+//simple pthread emulation by rti
+
+#include <windows.h>
+#include <process.h>
+
+typedef CRITICAL_SECTION pthread_mutex_t;
+
+static void pthread_mutex_init(pthread_mutex_t* mutex, void* nazo)
+{
+	InitializeCriticalSection(mutex);
+}
+
+static void pthread_mutex_destroy(pthread_mutex_t* mutex)
+{
+	DeleteCriticalSection(mutex);
+}
+
+static void pthread_mutex_lock(pthread_mutex_t* mutex)
+{
+	EnterCriticalSection(mutex);
+}
+
+static void pthread_mutex_unlock(pthread_mutex_t* mutex)
+{
+	LeaveCriticalSection(mutex);
+}
+
+struct _threadcallback{
+	static unsigned int __stdcall call(void* arg){
+		_threadcallback* _this = ((_threadcallback*)arg);
+		_this->start_routine(_this->arg);
+
+		delete _this;
+		return 0;
+	}
+		
+	void *(*start_routine) (void *);
+	void *arg;
+};
+
+typedef HANDLE pthread_t;
+typedef void* pthread_attr_t;
+static void pthread_create(pthread_t* thread, const pthread_attr_t *attr_null,void *(*start_routine) (void *), void *arg)
+{
+	_threadcallback* c = new _threadcallback;
+	c->start_routine = start_routine;
+	c->arg = arg;
+	
+	*thread = (HANDLE)_beginthreadex(NULL , 0 , _threadcallback::call , (void*)c ,  0 ,NULL );
+}
+
+static void pthread_join(pthread_t* thread,void * nazo)
+{
+	::WaitForSingleObject( thread , INFINITE);
+}

--- a/windows_support_include/strings.h
+++ b/windows_support_include/strings.h
@@ -1,0 +1,9 @@
+#pragma once
+
+#define bzero(b,len) (memset((b), '\0', (len)), (void) 0)  
+#define bcopy(b1,b2,len) (memmove((b2), (b1), (len)), (void) 0)
+#define bcmp(b1,b2,len) (memcmp(b1,b2,len))
+#define snprintf _snprintf
+#define strtok_r strtok_s
+
+#define __func__ __FUNCTION__

--- a/windows_support_include/unistd.h
+++ b/windows_support_include/unistd.h
@@ -1,0 +1,115 @@
+//<unistd.h> in windows
+//orignal soruce code: http://d.hatena.ne.jp/deraw/20070517/1179334643
+#ifndef _UNISTD_H_
+#define _UNISTD_H_
+#ifdef _WIN32
+#pragma once
+
+#include <io.h>
+/*
+access
+chmod
+chsize
+close
+creat
+dup
+dup2
+eof
+filelength
+isatty
+locking
+lseek
+mktemp
+open
+read
+setmode
+sopen
+tell
+umask
+unlink
+write
+*/
+#include <direct.h>
+/*
+chdir
+getcwd
+mkdir
+rmdir
+*/
+#include <process.h>
+/*
+cwait
+execl
+execle
+execlp
+execlpe
+execv
+execve
+execvp
+execvpe
+spawnl
+spawnle
+spawnlp
+spawnlpe
+spawnv
+spawnve
+spawnvp
+spawnvpe
+
+*/
+#pragma comment( lib, "ws2_32" )
+#include <winsock2.h>
+/*
+gethostname
+*/
+
+#include <process.h>
+/*
+_getpid
+*/
+#include <time.h>
+
+#ifdef	__cplusplus
+extern "C" {
+#endif
+
+typedef int	pid_t;			/* process id type	*/
+
+#ifndef _SSIZE_T_DEFINED
+typedef int ssize_t;
+#define _SSIZE_T_DEFINED
+#endif
+
+#ifndef vsnprintf
+#define vsnprintf _vsnprintf
+#endif
+
+#ifndef snprintf
+#define snprintf _snprintf
+#endif
+
+
+#define nice(incr) (SetPriorityClass(GetCurrentProcess(),incr))//TODO
+#define sleep(seconds) (Sleep(seconds*1000))
+#define usleep(useconds) (Sleep(useconds))
+
+#define stime(tp) UNISTD_stime(tp)
+__forceinline int UNISTD_stime(const time_t *tp ){
+	FILETIME ft;
+	SYSTEMTIME st;
+    LONGLONG ll = Int32x32To64(*tp, 10000000) + 116444736000000000;
+    ft.dwLowDateTime = (DWORD) ll;
+    ft.dwHighDateTime = (DWORD)(ll >>32);
+    FileTimeToSystemTime(&ft,&st);
+	return SetSystemTime(&st);
+}
+
+//<sys/stat.h>
+#define fstat64(fildes, stat) (_fstati64(fildes, stat))
+#define stat64(path, buffer) (_stati64(path,buffer))
+
+#ifdef	__cplusplus
+}
+#endif
+#endif /* _WIN32 */
+#endif /* _UNISTD_H_ */


### PR DESCRIPTION
I changed it so that it can build with Windows VisualStudio 2010.

*detail
In VisualStudio 2010, since initialization can not be done simultaneously with the declaration of member variables, we changed the initialization method.

In windows, since socket can not be manipulated by read / write, it changed to recv / send.

In windows, since socket is closed with "closesocket" instead of "close", we added ifdef.

I made a simple pthread compatibility routine.

We prepared the same as unistd.h.(This is based on what this person made.  http://d.hatena.ne.jp/deraw/20070517/1179334643 )

When building with windows, I use Bonjour SDK for Windows instead of avahi. However, since this is done in VisualStudio's project settings, there is nothing to modify the source code.

Changed the position of #include "ed25519-randombytes.h" in ed25519.c because of winsock include order.

With VisualStudio 2010, since inline specification did not go well, I dropped inline from chacha20_simple.c only with windows ifdef.

Removed _P () from srp / srp.h. With VisualStudio, we could not compile without removing it.



I wrote an explanation on my blog.( Japanese )
http://d.hatena.ne.jp/rti7743/20161124